### PR TITLE
feat: add list_sheets, apply_formula, get_range_snapshot tools

### DIFF
--- a/src/ethercalc-client.js
+++ b/src/ethercalc-client.js
@@ -58,6 +58,16 @@ export class EtherCalcClient {
     return { sheetId: decodeURIComponent(derivedId), url: this.viewUrl(derivedId) };
   }
 
+  async postCommand(sheetId, commandText) {
+    const response = await fetch(this.roomUrl(sheetId), {
+      method: "POST",
+      headers: { "content-type": "text/x-socialcalc" },
+      body: commandText,
+    });
+    if (!response.ok) throw new Error(`Failed to post command (${response.status})`);
+    return true;
+  }
+
   async getCells(sheetId) {
     const response = await fetch(this.roomUrl(sheetId, "/cells"));
     if (!response.ok) throw new Error(`Failed to fetch cells (${response.status})`);

--- a/src/server.js
+++ b/src/server.js
@@ -79,6 +79,30 @@ const toolSpecs = [
     annotations: { readOnlyHint: true, openWorldHint: false, destructiveHint: false },
     handler: ctx.summarizeSheet,
   },
+  {
+    name: "list_sheets",
+    title: "List sheets",
+    description: "List all spreadsheet IDs that have been created or opened in this session.",
+    inputSchema: schemas.listSheets,
+    annotations: { readOnlyHint: true, openWorldHint: false, destructiveHint: false },
+    handler: ctx.listSheets,
+  },
+  {
+    name: "apply_formula",
+    title: "Apply formula",
+    description: "Apply a spreadsheet formula (e.g. =SUM(A1:A10)) to a cell in A1 notation.",
+    inputSchema: schemas.applyFormula,
+    annotations: { readOnlyHint: false, openWorldHint: false, destructiveHint: false },
+    handler: ctx.applyFormula,
+  },
+  {
+    name: "get_range_snapshot",
+    title: "Get range snapshot",
+    description: "Read a rectangular range (e.g. A1:C5) or single cell from a sheet.",
+    inputSchema: schemas.getRangeSnapshot,
+    annotations: { readOnlyHint: true, openWorldHint: false, destructiveHint: false },
+    handler: ctx.getRangeSnapshot,
+  },
 ];
 
 function schemaToJsonSchema(schema) {

--- a/src/tool-logic.js
+++ b/src/tool-logic.js
@@ -2,6 +2,7 @@ import { EtherCalcClient } from "./ethercalc-client.js";
 import {
   appendRows,
   clearRange,
+  parseRange,
   setRangeValues,
   sortByColumn,
   stringifyCsv,
@@ -76,6 +77,29 @@ export const schemas = {
       maxRows: { type: "number" },
     },
   },
+  listSheets: {
+    type: "object",
+    properties: {
+      limit: { type: "number" },
+    },
+  },
+  applyFormula: {
+    type: "object",
+    required: ["sheetId", "cell", "formula"],
+    properties: {
+      sheetId: { type: "string" },
+      cell: { type: "string" },
+      formula: { type: "string" },
+    },
+  },
+  getRangeSnapshot: {
+    type: "object",
+    required: ["sheetId", "range"],
+    properties: {
+      sheetId: { type: "string" },
+      range: { type: "string" },
+    },
+  },
 };
 
 export function validateArgs(schema, args) {
@@ -90,6 +114,7 @@ export function validateArgs(schema, args) {
 
 export function makeAppContext({ ethercalcBaseUrl }) {
   const client = new EtherCalcClient(ethercalcBaseUrl);
+  const knownSheets = new Set();
 
   function widgetMeta(sheetId, action, extra = {}) {
     return {
@@ -106,6 +131,7 @@ export function makeAppContext({ ethercalcBaseUrl }) {
       if (headers.length) table.push(headers);
       table.push(...rows);
       const result = await client.createSheet({ sheetId, table: table.length ? table : [[""]] });
+      knownSheets.add(result.sheetId);
       return {
         content: [{ type: "text", text: `Opened sheet ${result.sheetId}.` }],
         structuredContent: {
@@ -120,6 +146,7 @@ export function makeAppContext({ ethercalcBaseUrl }) {
 
     async openSheet({ sheetId, maxRows = 20 }) {
       const table = await client.getTable(sheetId);
+      knownSheets.add(sheetId);
       return {
         content: [{ type: "text", text: `Loaded sheet ${sheetId}.` }],
         structuredContent: {
@@ -151,6 +178,7 @@ export function makeAppContext({ ethercalcBaseUrl }) {
       const table = await client.getTable(sheetId);
       const updated = setRangeValues(table, startCell, values);
       await client.putTable(sheetId, updated);
+      knownSheets.add(sheetId);
       return {
         content: [{ type: "text", text: `Updated ${values.length} row(s) starting at ${startCell} in ${sheetId}.` }],
         structuredContent: {
@@ -167,6 +195,7 @@ export function makeAppContext({ ethercalcBaseUrl }) {
       const table = await client.getTable(sheetId);
       const updated = appendRows(table, rows);
       await client.putTable(sheetId, updated);
+      knownSheets.add(sheetId);
       return {
         content: [{ type: "text", text: `Appended ${rows.length} row(s) to ${sheetId}.` }],
         structuredContent: {
@@ -182,6 +211,7 @@ export function makeAppContext({ ethercalcBaseUrl }) {
       const table = await client.getTable(sheetId);
       const updated = clearRange(table, range);
       await client.putTable(sheetId, updated);
+      knownSheets.add(sheetId);
       return {
         content: [{ type: "text", text: `Cleared ${range} in ${sheetId}.` }],
         structuredContent: {
@@ -197,6 +227,7 @@ export function makeAppContext({ ethercalcBaseUrl }) {
       const table = await client.getTable(sheetId);
       const updated = sortByColumn(table, column, hasHeader, direction);
       await client.putTable(sheetId, updated);
+      knownSheets.add(sheetId);
       return {
         content: [{ type: "text", text: `Sorted ${sheetId} by ${column} (${direction}).` }],
         structuredContent: {
@@ -223,6 +254,61 @@ export function makeAppContext({ ethercalcBaseUrl }) {
           sample: tablePreview(table, maxRows),
         },
         _meta: widgetMeta(sheetId, "summary"),
+      };
+    },
+
+    listSheets({ limit } = {}) {
+      const all = [...knownSheets];
+      const sheets = limit ? all.slice(0, limit) : all;
+      return {
+        content: [{ type: "text", text: `Known sheets: ${sheets.join(", ") || "(none)"}` }],
+        structuredContent: { sheets },
+        _meta: { action: "list-sheets" },
+      };
+    },
+
+    async applyFormula({ sheetId, cell, formula }) {
+      let table;
+      try {
+        await client.postCommand(sheetId, `set ${cell} formula ${formula}\n`);
+        table = await client.getTable(sheetId);
+      } catch {
+        table = await client.getTable(sheetId);
+        const updated = setRangeValues(table, cell, [[formula]]);
+        await client.putTable(sheetId, updated);
+        table = updated;
+      }
+      knownSheets.add(sheetId);
+      return {
+        content: [{ type: "text", text: `Applied formula ${formula} to ${cell} in ${sheetId}.` }],
+        structuredContent: {
+          sheetId,
+          cell,
+          formula,
+          preview: tablePreview(table),
+        },
+        _meta: widgetMeta(sheetId, "apply-formula", { cell, formula }),
+      };
+    },
+
+    async getRangeSnapshot({ sheetId, range }) {
+      const table = await client.getTable(sheetId);
+      const { startRow, endRow, startCol, endCol } = parseRange(range);
+      const subTable = table
+        .slice(startRow, endRow + 1)
+        .map((row) => row.slice(startCol, endCol + 1));
+      knownSheets.add(sheetId);
+      return {
+        content: [{ type: "text", text: `Range ${range} in ${sheetId}: ${subTable.length} row(s), ${subTable[0]?.length ?? 0} column(s).` }],
+        structuredContent: {
+          sheetId,
+          range,
+          data: subTable,
+          rowCount: subTable.length,
+          columnCount: subTable[0]?.length ?? 0,
+          preview: tablePreview(subTable),
+        },
+        _meta: widgetMeta(sheetId, "range-snapshot", { range }),
       };
     },
   };


### PR DESCRIPTION
## Summary
- **`list_sheets`** — tracks all opened/created sheets in-memory, returns the list so the widget can populate its tab bar
- **`apply_formula`** — posts SocialCalc commands to set cell formulas; falls back to CSV write if command endpoint fails
- **`get_range_snapshot`** — extracts a sub-table for a given A1 range (e.g. `B2:D8`), used by the widget's selection-aware chat feature

## Files changed
- `src/tool-logic.js` — 3 new schemas + handlers, `knownSheets` tracking in all existing tools
- `src/server.js` — 3 new tool registrations in `toolSpecs`
- `src/ethercalc-client.js` — `postCommand()` method for SocialCalc command posting

## Test plan
- [ ] `npm test` — 4 unit tests pass
- [ ] `list_sheets` returns [] initially, populates after create/open
- [ ] `apply_formula` sets a formula cell and reflects in snapshot
- [ ] `get_range_snapshot` returns correct sub-table for a given range

🤖 Generated with [Claude Code](https://claude.com/claude-code)